### PR TITLE
Expanded tests

### DIFF
--- a/httpcache.go
+++ b/httpcache.go
@@ -533,7 +533,7 @@ type cachingReadCloser struct {
 func (r *cachingReadCloser) Read(p []byte) (n int, err error) {
 	n, err = r.R.Read(p)
 	r.buf.Write(p[:n])
-	if err == io.EOF {
+	if err == io.EOF || n < len(p) {
 		r.OnEOF(bytes.NewReader(r.buf.Bytes()))
 	}
 	return n, err

--- a/httpcache.go
+++ b/httpcache.go
@@ -125,11 +125,11 @@ func NewTransport(c Cache, options ...TransportOption) *Transport {
 	return transport
 }
 
-type TransportOption func(transport *Transport)
+type TransportOption func(transport *Transport) *Transport
 
 // Adds the provided headers to the VaryIgnoreMask on the Transport.
 func WithVaryIgnoreMask(headers ...string) TransportOption {
-	return func(transport *Transport) {
+	return func(transport *Transport) *Transport {
 		mask := transport.VaryIgnoreMask
 		if mask == nil {
 			mask = make(map[string]bool)
@@ -140,6 +140,7 @@ func WithVaryIgnoreMask(headers ...string) TransportOption {
 		}
 
 		transport.VaryIgnoreMask = mask
+        return transport
 	}
 }
 

--- a/httpcache_test.go
+++ b/httpcache_test.go
@@ -100,6 +100,17 @@ func setup() {
 		w.Header().Set("Vary", "Accept")
 		w.Write([]byte("Some text content"))
 	}))
+	mux.HandleFunc("/varylastmodified", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "max-age=1")
+		w.Header().Set("Content-Type", "text/plain")
+		w.Header().Set("Vary", "Accept")
+		lm := "Fri, 14 Dec 2010 01:01:50 GMT"
+		if r.Header.Get("if-modified-since") == lm {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.Header().Set("last-modified", lm)
+	}))
 
 	mux.HandleFunc("/doublevary", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "max-age=3600")
@@ -1567,6 +1578,77 @@ func TestTransportVaryMatchesWithMask(t *testing.T) {
 		defer resp.Body.Close()
 		if resp.Header.Get(XFromCache) != "1" {
 			t.Fatalf(`XFromCache header isn't "1": %v`, resp.Header.Get(XFromCache))
+		}
+	}
+
+	// Verify initial request also still caches
+	req.Header.Set("Accept", "text/plain")
+	{
+		resp, err := s.client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		if resp.Header.Get(XFromCache) != "1" {
+			t.Fatalf(`XFromCache header isn't "1": %v`, resp.Header.Get(XFromCache))
+		}
+	}
+}
+
+func TestLastModifiedWithVaryIgnoreMask(t *testing.T) {
+	// Initial request
+	resetTest()
+	req, err := http.NewRequest("GET", s.server.URL+"/varylastmodified", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header.Set("Cache-Control", "max-age=1")
+	req.Header.Set("Accept", "text/plain")
+	{
+		resp, err := s.client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		if resp.Header.Get(XFromCache) != "" {
+			t.Fatalf(`XFromCache header isn't blank: %v`, resp.Header.Get(XFromCache))
+		}
+		_, err = ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Verify an immediate subsequent request is cached
+	{
+		resp, err := s.client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		if resp.Header.Get(XFromCache) != "1" {
+			t.Fatalf(`XFromCache header isn't "1": %v`, resp.Header.Get(XFromCache))
+		}
+		_, err = ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	time.Sleep(2*time.Second)
+	// Verify stale request is still cached
+	req.Header.Set("Accept", "text/html")
+	{
+		resp, err := s.client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		if resp.Header.Get(XFromCache) != "1" {
+			t.Fatalf(`XFromCache header isn't "1": %v`, resp.Header.Get(XFromCache))
+		}
+		_, err = ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
 		}
 	}
 }

--- a/httpcache_test.go
+++ b/httpcache_test.go
@@ -1570,3 +1570,20 @@ func TestTransportVaryMatchesWithMask(t *testing.T) {
 		}
 	}
 }
+
+func TestWithVaryIgnoreMask(t *testing.T) {
+	resetTest()
+	transport := NewTransport(NewMemoryCache())
+
+	headers := []string{"header1", "header2", "header3"}
+	WithVaryIgnoreMask(headers...)(transport)
+
+	switch {
+	case !transport.VaryIgnoreMask["Header1"]:
+		fallthrough
+	case !transport.VaryIgnoreMask["Header2"]:
+		fallthrough
+	case !transport.VaryIgnoreMask["Header3"]:
+		t.Fatalf(`Headers improperly added to mask: %v`, transport.VaryIgnoreMask)
+	}
+}


### PR DESCRIPTION
Adds a test for double-check stale requests work with the Vary header.

TEST=auto
These tests do, in fact, pass.